### PR TITLE
Support Middleman `v4.4.x`

### DIFF
--- a/lib/middleman-blog-similar/models/article.rb
+++ b/lib/middleman-blog-similar/models/article.rb
@@ -19,7 +19,7 @@ module Middleman
               GROUP BY rtr.article_id
               HAVING COUNT(*) > 0
               ORDER BY COUNT(*) * rtr.weight DESC, a.page_id DESC"
-          ids = res.to_hash.map { |h| h['article_id'] }
+          ids = res.to_ary.map { |h| h['article_id'] }
           page_id_map = {}
           articles = self.class.where(id: ids).select(:id, :page_id)
           articles.each do |a|

--- a/lib/middleman-blog-similar/version.rb
+++ b/lib/middleman-blog-similar/version.rb
@@ -1,7 +1,7 @@
 module Middleman
   module Blog
     module Similar
-      VERSION = '2.0.1'.freeze
+      VERSION = '2.1.0'.freeze
     end
   end
 end

--- a/middleman-blog-similar.gemspec
+++ b/middleman-blog-similar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features,spec}/*`.split("\0")
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.2.0'
-  s.add_runtime_dependency 'activerecord', '~> 5.0', '>= 5.0.0'
+  s.add_runtime_dependency 'activerecord', '~> 6.1', '>= 6.1.0'
   s.add_runtime_dependency 'middleman-core', '~> 4.0', '>= 4.0.0'
   s.add_runtime_dependency 'middleman-blog', '~> 4.0', '>= 4.0.0'
   s.add_dependency 'sqlite3', '~> 1.3'


### PR DESCRIPTION
## Reproduction

Cannot install library on Middleman `4.4.x` due to `activerecord` version mismatch:

```
middleman-blog-similar (~> 2.0.1) x64-mingw32 was resolved to 2.0.1, which
depends on
activerecord (~> 5.0, >= 5.0.0) x64-mingw32 was resolved to 5.0.1.rc1,
which depends on
        activesupport (= 5.0.1.rc1) x64-mingw32

    middleman (~> 4.4.2) x64-mingw32 was resolved to 4.4.2, which depends on
middleman-core (= 4.4.2) x64-mingw32 was resolved to 4.4.2, which depends
on
        activesupport (>= 6.1, < 7.0) x64-mingw32
```

## Fix

* Bump activerecord to >= `6.1` which auto updates `activesupport` >= `6.1`
* Modify `article.rb` to use new API: `to_hash` -> `to_ary`
* Update `middleman-blog-similar` VERSION to `2.1.0` due to dependency upgrade.


## Possible Issues

* Not sure if `middleman` version `4.4.x` is the minimum version for `activesupport` >= `6.1`. 
* Have not tested initialization code for possible API breakage due to existing SQL database.


This PR was created with minimal testing. Please use as much or as little as possible for the changes. I have found  your library to be very helpful so would appreciate it being updated to support latest `middleman`.

Best,
PI